### PR TITLE
Fix CDi profile renaming to cd-i (#17)

### DIFF
--- a/generate_rt4k_mister_dv1_profiles.sh
+++ b/generate_rt4k_mister_dv1_profiles.sh
@@ -184,6 +184,7 @@ declare -a renaming_rules=(
   "GameboyColor.rt4 GBC.rt4"
   "PocketChallengeV2.rt4 PocketChalleng.rt4"
   "WonderSwanColor.rt4 WonderSwanColo.rt4"
+  "CDi.rt4 cd-i.rt4"
 )
 
 # Replace associative array with two regular arrays


### PR DESCRIPTION
- Addresses Issue #15: CDi profile needs to be renamed to "cd-i"
- Added "CDi.rt4 cd-i.rt4" to renaming_rules array
- RBF is CDi but the actual setname is "cd-i"
- Script will now automatically rename CDi.rt4 to cd-i.rt4 during processing

Fixes #15